### PR TITLE
support installing on openshift

### DIFF
--- a/cmd/install/openshift.go
+++ b/cmd/install/openshift.go
@@ -1,0 +1,33 @@
+package install
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/solo-io/glooctl/pkg/install/openshift"
+	"github.com/spf13/cobra"
+)
+
+func openshiftCmd() *cobra.Command {
+	dryRun := false
+	cmd := &cobra.Command{
+		Use:   "openshift",
+		Short: "install gloo on OpenShift",
+		Long: `
+	Installs latest gloo on OpenShift. It downloads the latest installation YAML
+	file and installs to the current OpenShift context.`,
+		Run: func(c *cobra.Command, a []string) {
+			err := openshift.Install(dryRun)
+			if err != nil {
+				fmt.Printf("Unable to isntall gloo on OpenShift %q\n", err)
+				os.Exit(1)
+			}
+			if !dryRun {
+				fmt.Println("Gloo successfully installed.")
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false,
+		"If true, only print the objects that will be setup, without sending it")
+	return cmd
+}

--- a/cmd/install/root.go
+++ b/cmd/install/root.go
@@ -9,6 +9,6 @@ func Cmd() *cobra.Command {
 		Use:   "install",
 		Short: "install gloo on different platforms",
 	}
-	cmd.AddCommand(dockerCmd(), kubeCmd())
+	cmd.AddCommand(dockerCmd(), kubeCmd(), openshiftCmd())
 	return cmd
 }

--- a/pkg/install/openshift/openshift.go
+++ b/pkg/install/openshift/openshift.go
@@ -1,0 +1,20 @@
+package openshift
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Install setups Gloo on OpenShift using oc and current context
+func Install(dryRun bool) error {
+	// running oc with latest install.yaml
+	args := []string{"apply", "--filename",
+		"https://raw.githubusercontent.com/solo-io/gloo/master/install/openshift/install.yaml"}
+	if dryRun {
+		args = append(args, "--dry-run=true")
+	}
+	cmd := exec.Command("oc", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
- supports installing on openshift using openshift client 'oc'
- not merging common code between openshift and kube to allow them to change independently (good idea?)