### PR TITLE
Improved UX for route commands

### DIFF
--- a/cmd/route/delete.go
+++ b/cmd/route/delete.go
@@ -23,11 +23,14 @@ func deleteCmd(opts *bootstrap.Options) *cobra.Command {
 		Use:   "delete",
 		Short: "delete a route",
 		Long: `
-Delete a route based on either the definition in the YAML file
-or based on the route matcher and destintation provided in the CLI.
+There are three ways to select the route to delete:
 
-While selecting routes to delete, glooctl matches routes based on 
-matcher and destintation only. It doesn't include extensions.`,
+  1. Using the interactive mode
+  2. Passing the index of the route
+  3. Specifying the route details of the matcher and destination
+     in the CLI arguments or via YAML file.
+	 While selecting routes to delete, glooctl matches routes based
+	 on matcher and destintation only. It doesn't include extensions.`,
 		Run: func(c *cobra.Command, args []string) {
 			sc, err := configstorage.Bootstrap(*opts)
 			if err != nil {
@@ -39,6 +42,7 @@ matcher and destintation only. It doesn't include extensions.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&routeOpt.Interactive, "interactive", "i", false, "interactive mode")
+	cmd.Flags().IntVar(&routeOpt.Index, "index", 0, "index of the route you want to delete")
 	return cmd
 }
 
@@ -49,6 +53,7 @@ func runDelete(sc storage.Interface) {
 		os.Exit(1)
 	}
 	fmt.Println("Using virtual service:", vs.Name)
+	routeOpt.Virtualservice = vs.Name
 	routes := vs.GetRoutes()
 
 	filtered, err := removeRoutes(sc, routes, routeOpt)

--- a/cmd/route/delete_test.go
+++ b/cmd/route/delete_test.go
@@ -21,4 +21,13 @@ var _ = Describe("Deleting route", func() {
 			ExpectExitCode(0)
 	})
 
+	It("when using index to specify route should fail when index is too large", func() {
+		helper.RunWithArgs("route", "delete", "--index", "100").
+			ExpectExitCodeAndOutput(1, "invalid index")
+	})
+
+	It("when deleting with index the route should be delete", func() {
+		helper.RunWithArgs("route", "delete", "--index", "2").
+			ExpectExitCodeAndOutput(0, "POST", "\\*")
+	})
 })

--- a/cmd/route/update_test.go
+++ b/cmd/route/update_test.go
@@ -23,4 +23,9 @@ var _ = Describe("Update routes", func() {
 			ExpectExitCodeAndOutput(0, "/exact2", "exact-upstream")
 	})
 
+	It("using index to specify old route and change just the matcher path", func() {
+		helper.RunWithArgs("route", "update", "--index", "2", "--path-regex", "/regex").
+			ExpectExitCodeAndOutput(0, "/regex", "test-upstream")
+	})
+
 })

--- a/pkg/route/print.go
+++ b/pkg/route/print.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -29,13 +30,13 @@ func (d *Destination) String() string {
 // PrintTable prints the list of routes as a table
 func PrintTable(list []*v1.Route, w io.Writer) {
 	table := tablewriter.NewWriter(w)
-	table.SetHeader([]string{"Matcher", "Type", "Verb", "Header", "Upstream", "Function", "Extension"})
+	table.SetHeader([]string{"Id", "Matcher", "Type", "Verb", "Header", "Upstream", "Function", "Extension"})
 
-	for _, r := range list {
+	for i, r := range list {
 		matcher, rType, verb, headers := Matcher(r)
 		ext := Extension(r)
 		for _, d := range Destinations(r) {
-			table.Append([]string{matcher, rType, verb, headers, d.Upstream, d.Function, ext})
+			table.Append([]string{strconv.Itoa(i + 1), matcher, rType, verb, headers, d.Upstream, d.Function, ext})
 		}
 	}
 


### PR DESCRIPTION
update:
- use index to specify old route
- specify only the parameter that has changed instead of the full new
route

delete:
- use index to specify the route to delete